### PR TITLE
fixes oauth2 returns null #1104

### DIFF
--- a/lib/web/oauth2.php
+++ b/lib/web/oauth2.php
@@ -64,10 +64,13 @@ class OAuth2 extends \Magic {
 		$response=$web->request($uri,$options);
 		if ($response['error'])
 			user_error($response['error'],E_USER_ERROR);
-		return $response['body'] &&
-			preg_grep('/HTTP\/1\.\d 200/',$response['headers'])?
-			json_decode($response['body'],TRUE):
-			FALSE;
+		if (isset($response['body']) && preg_grep('/HTTP\/1\.\d 200/',$response['headers']))
+		{
+		    if ($token = json_decode($response['body'],TRUE))
+		        return $token;
+		    return $response['body'];
+		}
+			return FALSE;
 	}
 
 	/**


### PR DESCRIPTION
not all oauth endpoints will return a JSON formatted string. just return the string if this happens